### PR TITLE
Fixed negation emulation (missed it in my last PR)

### DIFF
--- a/safe-math/safe-math.h
+++ b/safe-math/safe-math.h
@@ -854,11 +854,6 @@ PSNIP_SAFE_DEFINE_UNSIGNED_MOD(uint64_t, uint64, UINT64_MAX)
 
 #endif /* !defined(PSNIP_SAFE_NO_FIXED) */
 
-#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
-/* The are no fixed-length or size selections because they cause an
- * error about _Generic specifying two compatible types.  Hopefully
- * this doesn't cause problems on exotic platforms, but if it does
- * please let me know and I'll try to figure something out. */
 #define PSNIP_SAFE_C11_GENERIC_SELECTION(res, op) \
   _Generic((*res), \
 	   char: psnip_safe_char_##op, \
@@ -876,6 +871,20 @@ PSNIP_SAFE_DEFINE_UNSIGNED_MOD(uint64_t, uint64, UINT64_MAX)
   PSNIP_SAFE_C11_GENERIC_SELECTION(res, op)(res, a, b)
 #define PSNIP_SAFE_C11_GENERIC_UNARY_OP(op, res, v) \
   PSNIP_SAFE_C11_GENERIC_SELECTION(res, op)(res, v)
+
+#if defined(PSNIP_SAFE_HAVE_BUILTINS)
+#define psnip_safe_add(res, a, b) !__builtin_add_overflow(a, b, res)
+#define psnip_safe_sub(res, a, b) !__builtin_sub_overflow(a, b, res)
+#define psnip_safe_mul(res, a, b) !__builtin_mul_overflow(a, b, res)
+#define psnip_safe_div(res, a, b) !__builtin_div_overflow(a, b, res)
+#define psnip_safe_mod(res, a, b) !__builtin_mod_overflow(a, b, res)
+#define psnip_safe_neg(res, v)    PSNIP_SAFE_C11_GENERIC_UNARY_OP (neg, res, v)
+
+#elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
+/* The are no fixed-length or size selections because they cause an
+ * error about _Generic specifying two compatible types.  Hopefully
+ * this doesn't cause problems on exotic platforms, but if it does
+ * please let me know and I'll try to figure something out. */
 
 #define psnip_safe_add(res, a, b) PSNIP_SAFE_C11_GENERIC_BINARY_OP(add, res, a, b)
 #define psnip_safe_sub(res, a, b) PSNIP_SAFE_C11_GENERIC_BINARY_OP(sub, res, a, b)

--- a/safe-math/safe-math.h
+++ b/safe-math/safe-math.h
@@ -532,8 +532,9 @@ PSNIP_SAFE_DEFINE_LARGER_UNSIGNED_OPS(uint64_t, uint64)
 #define PSNIP_SAFE_DEFINE_SIGNED_NEG(T, name, min, max) \
   PSNIP_SAFE__FUNCTION _Bool \
   psnip_safe_##name##_neg (T* res, T value) { \
-    *res = -value; \
-    return !PSNIP_SAFE_UNLIKELY(value == min); \
+    _Bool r = value != min; \
+    *res = PSNIP_SAFE_LIKELY(r) ? -value : max; \
+    return r; \
   }
 
 #if defined(PSNIP_SAFE_HAVE_BUILTIN_OVERFLOW)

--- a/tests/safe-math.c
+++ b/tests/safe-math.c
@@ -114,7 +114,7 @@ test_safe_generic(const MunitParameter params[], void* user_data) {
     munit_assert_true(psnip_safe_##name##_neg(&result, max)); \
     munit_assert_##name(result, ==, -max); \
     munit_assert_false(psnip_safe_##name##_neg(&result, min)); \
-    munit_assert_##name(result, ==, min); \
+    munit_assert_##name(result, ==, max); \
     return MUNIT_OK; \
   }
 


### PR DESCRIPTION
The second commit replaces _Generic macros with generic builtins if they're available.
It makes the preprocessor output less bulky.