### PR TITLE
docs: fix simple typo, architecure -> architecture

### DIFF
--- a/builtin/README.md
+++ b/builtin/README.md
@@ -142,7 +142,7 @@ different compilers or architectures.
 
 Creating implementations of one compiler's builtins using builtins
 from another is probably your best bet to improve performance.
-Another useful possibility is using architecure-specific builtins, or
+Another useful possibility is using architecture-specific builtins, or
 even embedded assembly, when they are available.
 
 ### Architecture-specific builtins


### PR DESCRIPTION
There is a small typo in builtin/README.md.

Should read `architecture` rather than `architecure`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md