### PR TITLE
Add extra !defined(__cplusplus) for Solaris

### DIFF
--- a/safe-math/safe-math.h
+++ b/safe-math/safe-math.h
@@ -58,7 +58,7 @@
 #  define PSNIP_SAFE__FUNCTION PSNIP_SAFE__COMPILER_ATTRIBUTES static PSNIP_SAFE__INLINE
 #endif
 
-#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+#if !defined(__cplusplus) && defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
 #  define psnip_safe_bool _Bool
 #else
 #  define psnip_safe_bool int


### PR DESCRIPTION
Due to a [bug in g++ on Solaris](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=57025), we need an extra check in order to compile there. See also https://github.com/apache/arrow/pull/9550.